### PR TITLE
Mod 2**255 vs mod 255

### DIFF
--- a/site/site.js
+++ b/site/site.js
@@ -94,7 +94,7 @@
             if (!n || !point) {
                 return;
             }
-            n %= 255n;
+            n %= 2n**255n;
             point %= field.p;
             let { x, z } = curve.pointMult(point, n);
             let X = curve.X(x, z);


### PR DESCRIPTION
For the "Public key multiplier" the private key is modulo 255 instead of modulo 2**255.